### PR TITLE
Fix address data docs

### DIFF
--- a/qrbill.dtx
+++ b/qrbill.dtx
@@ -362,7 +362,7 @@
 % Country& \multicolumn{2}{c}{Country Code}\\\bottomrule
 % \end{tabular}
 % \end{center}
-% To set an address of type \enquote{K} one can use they option key \latexinline{debtor} or \latexinline{creditor}. Type \enquote{S} can be achieved using the starred variant (\latexinline{debtor*}/\latexinline{creditor*}).
+% To set an address of type \enquote{S}, one can use the option keys \latexinline{debtor} or \latexinline{creditor}. Type \enquote{K} can be achieved using the starred variants (\latexinline{debtor*}/\latexinline{creditor*}).
 %
 % \begin{minipage}{.5\linewidth}
 % \begin{doccode}


### PR DESCRIPTION
According to the examples, the normal variant is S, the starred is K.

![image](https://user-images.githubusercontent.com/625793/186751006-ba34e262-d01a-43a3-9655-22a6730515b0.png)

Also some minor phrasing changes.